### PR TITLE
Various updates.

### DIFF
--- a/src/longbow/__main__.py
+++ b/src/longbow/__main__.py
@@ -36,26 +36,6 @@ for p in [p for p in pkgutil.iter_modules(longbow.__path__) if p.ispkg]:
     exec(f"from .{p.name} import command as {p.name}")
     exec(f"main_entry.add_command({p.name}.main)")
 
-# Update with new sub-commands:
-# NOTE: Keeping ths around in case we hate my solution above.
-
-# from .inspect import command as inspect
-# from .segment import command as segment
-# from .annotate import command as annotate
-# from .train import command as train
-# from .scsplit import command as scsplit
-# from .discriminate import command as discriminate
-# from .filter import command as filter
-# from .extract import command as extract
-
-# main_entry.add_command(annotate.main)
-# main_entry.add_command(segment.main)
-# main_entry.add_command(train.main)
-# main_entry.add_command(inspect.main)
-# main_entry.add_command(scsplit.main)
-# main_entry.add_command(discriminate.main)
-# main_entry.add_command(filter.main)
-# main_entry.add_command(extract.main)
 
 if __name__ == "__main__":
     main_entry()  # pylint: disable=E1120

--- a/src/longbow/demultiplex/command.py
+++ b/src/longbow/demultiplex/command.py
@@ -20,7 +20,7 @@ from ..utils.model import LibraryModel
 
 
 logging.basicConfig(stream=sys.stderr)
-logger = logging.getLogger("discriminate")
+logger = logging.getLogger("demultiplex")
 click_log.basic_config(logger)
 
 
@@ -44,7 +44,7 @@ click_log.basic_config(logger)
 @click.option(
     "-o",
     "--out-base-name",
-    default="longbow_discriminated",
+    default="longbow_demultiplexed",
     required=False,
     show_default=True,
     type=str,
@@ -86,7 +86,7 @@ def main(pbi, out_base_name, threads, input_bam):
 
     for i in range(threads):
         p = mp.Process(
-            target=_worker_discrimination_fn, args=(input_data_queue, results, model_list, i)
+            target=_worker_demux_fn, args=(input_data_queue, results, model_list, i)
         )
         p.start()
         worker_pool.append(p)
@@ -210,7 +210,7 @@ def _write_thread_fn(out_queue, out_bam_header, out_bam_base_name, model_list, r
             out_file.close()
 
 
-def _worker_discrimination_fn(in_queue, out_queue, model_list, worker_num):
+def _worker_demux_fn(in_queue, out_queue, model_list, worker_num):
     """Function to run in each subthread / subprocess.
     Annotates each read with both models and assigns the read to the model with the better score."""
 

--- a/src/longbow/extract/command.py
+++ b/src/longbow/extract/command.py
@@ -142,9 +142,12 @@ def main(pbi, out_file, force, base_padding, leading_adapter, trailing_adapter, 
                 end_marker_list = [(i, s) for i, s in enumerate(segments) if s.name == trailing_adapter]
 
                 if len(start_marker_list) != len(end_marker_list):
-                    logger.warning(f"Found %d start markers and %d end markers.  Only looking at first %d pairs.",
+                    logger.warning(f"Found %d start markers and %d end markers.  Only looking at first %d pairs.  "
+                                   f"(starts: %s, ends: %s)",
                                    len(start_marker_list), len(end_marker_list),
-                                   min(len(start_marker_list), len(end_marker_list)))
+                                   min(len(start_marker_list), len(end_marker_list)),
+                                   " ".join([f"{i}:{s.name}" for i, s in start_marker_list]),
+                                   " ".join([f"{i}:{s.name}" for i, s in end_marker_list]))
 
                 extracted_segment = False
 

--- a/src/longbow/utils/model.py
+++ b/src/longbow/utils/model.py
@@ -126,6 +126,13 @@ class LibraryModel:
 
         # If we've made it here and we have seen at least 1 key adapter, then we have a valid array:
         is_valid = True if num_key_adapters_found > 0 else False
+
+        # Except!  If we have an array singleton and it's the terminal overhang adapter,
+        # then we do NOT have a valid array:
+        if is_valid and (num_key_adapters_found == 1) and \
+                (self.key_adapters[first_key_adapter_index] == self.array_element_structure[-1][-1]):
+            is_valid = False
+
         return is_valid, num_key_adapters_found, first_key_adapter_index
 
     def extract_key_segment_names(self, segment_names):
@@ -196,7 +203,8 @@ class LibraryModel:
         #            filter out all segments from self.array_element_structure with names longer than 1 char.  We then
         #            use these in order to characterize the reads.
 
-        ordered_key_adapters = [s for array in self.array_element_structure for s in array if len(s) == 1]
+        ordered_key_adapters = [s for array in self.array_element_structure
+                                for s in array if len(s) == 1]
         return ordered_key_adapters
 
     @staticmethod
@@ -526,7 +534,10 @@ class LibraryModel:
 
     @staticmethod
     def build_and_return_mas_seq_8_model():
-        """Create and return the model for the prototype 8 element MAS-seq array."""
+        """Create and return the model for the prototype 8 element MAS-seq array.
+
+        Included for completeness, but for now this SHOULD NOT BE USED.
+        """
         return LibraryModel(
             name="mas8prototype",
             version="1.0.0",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,6 +7,7 @@ def assert_bam_files_equal(file1, file2, order_matters=False, compare_header=Fal
 
     if order_matters and compare_header:
         assert filecmp.cmp(file1, file2)
+        return
 
     with pysam.AlignmentFile(file1, "rb", check_sq=False, require_index=False) as bam1, \
         pysam.AlignmentFile(file2, "rb", check_sq=False, require_index=False) as bam2:


### PR DESCRIPTION
- Removed extra code from __main__
- Renamed discriminate to demultiplex
- Added extra logging to removed segments in the extract command
- Fixed a bug in `filter`.  Before a read could be considered valid if
  it had a single key overhang that was the final overhang of a model.
  Now the final overhang singleton is no longer considered valid.