### PR TITLE
Generalization to demultiplexing.

### DIFF
--- a/src/longbow/demultiplex/command.py
+++ b/src/longbow/demultiplex/command.py
@@ -51,34 +51,16 @@ click_log.basic_config(logger)
     help="base name for output files",
 )
 @click.option(
-    "-m",
-    "--model",
-    required=False,
+    "-d",
+    "--demux-on-tag",
     type=str,
-    multiple=True,
-    show_default=True,
-    default=longbow.utils.constants.DEFAULT_DEMULTIPLEX_MODELS,
-    help="Models to use to demultiplex the input bam file.  Given model must either be a Longbow built-in model, "
-         "or a valid Longbow model json file.  If specified, this option must be specified at least twice."
-)
-@click.option(
-    "--max-length",
-    type=int,
-    default=longbow.utils.constants.DEFAULT_MAX_READ_LENGTH,
+    default="YN",
     show_default=True,
     required=False,
-    help="Maximum length of a read to process.  Reads beyond this length will not be annotated."
-)
-@click.option(
-    "--min-rq",
-    type=float,
-    default=-2,
-    show_default=True,
-    required=False,
-    help="Minimum ccs-determined read quality for a read to be annotated.  CCS read quality range is [-1,1]."
+    help="BAM tag on which to demultiplex (e.g. YN, BC)"
 )
 @click.argument("input-bam", default="-" if not sys.stdin.isatty() else None, type=click.File("rb"))
-def main(pbi, out_base_name, threads, model, max_length, min_rq, input_bam):
+def main(pbi, threads, out_base_name, demux_on_tag, input_bam):
     """Separate reads into files based on which model they fit best.
 
     Resulting reads will be annotated with the model they best fit as well as the score and segments for that model."""
@@ -94,7 +76,7 @@ def main(pbi, out_base_name, threads, model, max_length, min_rq, input_bam):
     read_count = None
     if os.path.exists(pbi):
         read_count = bam_utils.load_read_count(pbi)
-        logger.info("Annotating %d reads", read_count)
+        logger.info("Processing %d reads", read_count)
 
     # Create queues for data:
     queue_size = threads * 2 if threads < 10 else 20
@@ -102,55 +84,12 @@ def main(pbi, out_base_name, threads, model, max_length, min_rq, input_bam):
     input_data_queue = manager.Queue(maxsize=queue_size)
     results = manager.Queue()
 
-    # Use defaults if model is not specified:
-    model_names = longbow.utils.constants.DEFAULT_DEMULTIPLEX_MODELS
-
-    if len(model) == 0:
-        logger.info(f"No models specified.  Using defaults.")
-    elif len(model) == 1:
-        logger.fatal(f"Only one model specified.  Demultiplex requires at least two models.")
-        sys.exit(1)
-    else:
-        # Ensure the user didn't specify the same model more than once:
-        for m in set(model):
-            count = 0
-            for other in model:
-                if m == other:
-                    count += 1
-            if count > 1:
-                logger.warning(f"Model specified more than once: {m} ({count}x).  "
-                               f"Ignoring all occurrences after the first.")
-
-        model_names = set(model)
-        
-        if len(model_names) == 1:
-            logger.fatal(f"Only one model specified.  Demultiplex requires at least two models.")
-            sys.exit(1)
-
-        # Validate that the models we've been given exist:
-        for m in model:
-            if not LibraryModel.has_prebuilt_model(m) and not os.path.exists(m):
-                logger.fatal(f"Unknown model specified: {m}")
-                sys.exit(1)
-
-    logger.info(f"Demultiplexing with models: {', '.join(model_names)}")
-
-    # Create a dictionary of models to use to annotate and score our reads:
-    model_list = []
-    for m in model_names:
-        # Get our model:
-        if LibraryModel.has_prebuilt_model(m):
-            model_list.append(LibraryModel.build_pre_configured_model(m))
-        else:
-            logger.info(f"Loading model from json file: %s", m)
-            model_list.append(LibraryModel.from_json_file(m))
-
     # Start worker sub-processes:
     worker_pool = []
 
     for i in range(threads):
         p = mp.Process(
-            target=_worker_demux_fn, args=(input_data_queue, results, model_list, i, max_length, min_rq)
+            target=_worker_demux_fn, args=(input_data_queue, results, i, demux_on_tag)
         )
         p.start()
         worker_pool.append(p)
@@ -161,13 +100,12 @@ def main(pbi, out_base_name, threads, model, max_length, min_rq, input_bam):
     ) as bam_file:
 
         # Get our header from the input bam file:
-        out_header = bam_utils.create_bam_header_with_program_group(logger.name, bam_file.header, models=model_list)
+        out_header = bam_utils.create_bam_header_with_program_group(logger.name, bam_file.header)
 
         # Start output worker:
-        res = manager.dict({"num_reads_annotated": 0, "num_sections": 0,
-                            "model_reads_annotated_count_dict": dict()})
+        res = manager.dict({"num_reads_demultiplexed": 0, "num_reads_discarded": 0})
         output_worker = mp.Process(
-            target=_write_thread_fn, args=(results, out_header, out_base_name, model_list, res, read_count)
+            target=_write_thread_fn, args=(results, out_header, out_base_name, res, read_count)
         )
         output_worker.start()
 
@@ -196,24 +134,19 @@ def main(pbi, out_base_name, threads, model, max_length, min_rq, input_bam):
         output_worker.join()
 
     logger.info(
-        f"Annotated {res['num_reads_annotated']} reads with {res['num_sections']} total sections."
+        f"Demultiplexed {res['num_reads_demultiplexed']} reads. Discarded {res['num_reads_discarded']}."
     )
-    for model_name, count in res["model_reads_annotated_count_dict"].items():
-        logger.info(f"Model {model_name} annotated {count} reads.")
 
     et = time.time()
     logger.info(f"Done. Elapsed time: {et - t_start:2.2f}s. "
-                f"Overall processing rate: {res['num_reads_annotated']/(et - t_start):2.2f} reads/s.")
+                f"Overall processing rate: {(res['num_reads_demultiplexed']+res['num_reads_discarded'])/(et - t_start):2.2f} reads/s.")
 
 
-def _write_thread_fn(out_queue, out_bam_header, out_bam_base_name, model_list, res, read_count):
+def _write_thread_fn(out_queue, out_bam_header, out_bam_base_name, res, read_count):
     """Thread / process fn to write out all our data."""
 
     try:
-        out_file_dict = {
-            model.name: pysam.AlignmentFile(f"{out_bam_base_name}_{model.name}.bam", "wb", header=out_bam_header)
-            for model in model_list
-        }
+        out_file_dict = {}
 
         with tqdm.tqdm(
             desc="Progress",
@@ -222,8 +155,6 @@ def _write_thread_fn(out_queue, out_bam_header, out_bam_base_name, model_list, r
             file=sys.stderr,
             total=read_count
         ) as pbar:
-
-            ssw_aligner = ssw.Aligner()
 
             while True:
                 # Wait for some output data:
@@ -237,36 +168,23 @@ def _write_thread_fn(out_queue, out_bam_header, out_bam_base_name, model_list, r
                     continue
 
                 # Unpack data:
-                read, ppath, logp, is_rc, model_name = raw_data
+                read, tag_value = raw_data
 
-                # Get our model for this read.
-                # NOTE: We should always have a model after this code because all models that can be assigned to the
-                #       reads are in the model_list.
-                model = None
-                for m in model_list:
-                    if m.name == model_name:
-                        model = m
-                        break
+                if tag_value is not None:
+                    read = pysam.AlignedSegment.fromstring(read, out_bam_header)
 
-                # Condense the output annotations so we can write them out with indices:
-                segments = bam_utils.collapse_annotations(ppath)
+                    if tag_value not in out_file_dict:
+                        out_file_dict[tag_value] = pysam.AlignmentFile(
+                            f'{out_bam_base_name}.{tag_value}.bam',
+                            "wb",
+                            header=out_bam_header
+                        )
 
-                read = pysam.AlignedSegment.fromstring(read, out_bam_header)
+                    out_file_dict[tag_value].write(read)
 
-                # Write our our read:
-                bam_utils.write_annotated_read(
-                    read, segments, is_rc, logp, model, ssw_aligner, out_file_dict[model_name]
-                )
-
-                # Increment our counters:
-                res["num_reads_annotated"] += 1
-                res["num_sections"] += len(segments)
-                count_dict = res["model_reads_annotated_count_dict"]
-                try:
-                    count_dict[model_name] += 1
-                except KeyError:
-                    count_dict[model_name] = 1
-                res["model_reads_annotated_count_dict"] = count_dict
+                    res["num_reads_demultiplexed"] += 1
+                else:
+                    res["num_reads_discarded"] += 1
 
                 pbar.update(1)
     finally:
@@ -274,11 +192,11 @@ def _write_thread_fn(out_queue, out_bam_header, out_bam_base_name, model_list, r
             out_file.close()
 
 
-def _worker_demux_fn(in_queue, out_queue, model_list, worker_num, max_length, min_rq):
+def _worker_demux_fn(in_queue, out_queue, worker_num, demux_on_tag):
     """Function to run in each subthread / subprocess.
-    Annotates each read with both models and assigns the read to the model with the better score."""
+    Simply pulls user-specified tag from read."""
 
-    num_reads_segmented = 0
+    num_reads_processed = 0
 
     while True:
         # Wait until we get some data.
@@ -300,67 +218,10 @@ def _worker_demux_fn(in_queue, out_queue, model_list, worker_num, max_length, mi
             read, pysam.AlignmentHeader.from_dict(dict())
         )
 
-        # Check for max length and min quality:
-        if len(read.query_sequence) > max_length:
-            logger.warning(f"Read is longer than max length.  "
-                           f"Skipping: {read.query_name} ({len(read.query_sequence)} > {max_length})")
-            continue
-        elif read.get_tag("rq") < min_rq:
-            logger.warning(f"Read quality is below the minimum.  "
-                           f"Skipping: {read.query_name} ({read.get_tag('rq')} < {min_rq})")
-            continue
+        tag_value = read.get_tag(demux_on_tag) if read.has_tag(demux_on_tag) else None
 
-        # Process and place our data on the output queue:
-        segment_info = _annotate_and_assign_read_to_model(read, model_list)
+        out_queue.put((read.to_string(), tag_value))
 
-        out_queue.put(segment_info)
-        num_reads_segmented += 1
+        num_reads_processed += 1
 
-    logger.debug(f"Worker %d: Num reads segmented: %d", worker_num, num_reads_segmented)
-
-
-def _annotate_and_assign_read_to_model(read, model_list):
-    """Annotate the given read with all given models and assign the read to the model with the best score."""
-
-    best_model = ""
-    best_logp = -math.inf
-    best_path = None
-    best_fit_is_rc = False
-    model_scores = dict()
-    for model in model_list:
-
-        _, ppath, logp, is_rc = _annotate_read(read, model)
-
-        model_scores[model.name] = logp
-
-        if logp > best_logp:
-            best_model = model.name
-            best_logp = logp
-            best_path = ppath
-            best_fit_is_rc = is_rc
-
-    # Provide some info as to which model was chosen:
-    if logger.isEnabledFor(logging.DEBUG):
-        logger.debug("%s model scores: %s", read.query_name, str(model_scores))
-        logger.debug(
-            "Sequence %s scored best with model%s: %s (%2.4f)",
-            read.query_name,
-            " in RC " if best_fit_is_rc else "",
-            best_model,
-            best_logp
-        )
-
-    return read.to_string(), best_path, best_logp, best_fit_is_rc, best_model
-
-
-def _annotate_read(read, model):
-    is_rc = False
-    logp, ppath = model.annotate(read.query_sequence)
-
-    rc_logp, rc_ppath = model.annotate(bam_utils.reverse_complement(read.query_sequence))
-    if rc_logp > logp:
-        logp = rc_logp
-        ppath = rc_ppath
-        is_rc = True
-
-    return read.to_string(), ppath, logp, is_rc
+    logger.debug(f"Worker %d: Num reads processed: %d", worker_num, num_reads_processed)

--- a/tests/unit/test_bam_utils.py
+++ b/tests/unit/test_bam_utils.py
@@ -1,0 +1,108 @@
+import pytest
+from longbow.utils import bam_utils
+from longbow.utils import model
+
+import pysam
+
+
+# fp = tempfile.TemporaryFile()
+# with pysam.AlignmentFile(fp, mode="wb", header=header, check_header=True, check_sq=False) as bam_file:
+#     read = pysam.AlignedSegment(header)
+#     read.query_name = f'{movie_name}/{zmw}/ccs'
+#     read.mapping_quality = 255
+#     read.query_sequence  = 'AAACCCGGGTTT'
+#     read.query_qualities = [10] * len(read.query_sequence)
+#     read.set_tag('RG', rgid)
+#     read.set_tag('np', 5)
+#     read.set_tag('rq', 0.999)
+#     read.set_tag('zm', zmw)
+#     read.set_tag('YN', model)
+#     # SG:Z:TPV2_adapter:0-58,cDNA:59-292
+#     # YS:f:-462.004
+#     # RC:i:1
+#     # XQ:Z:20/104,0/0
+#     # YQ:Z:0.1923
+#     bam_file.write(read)
+
+
+@pytest.fixture
+def bam_header_without_program_group():
+    rgid = '01234567'
+    movie_name = 'm00001e_210000_000000'
+
+    header = pysam.AlignmentHeader.from_dict({
+        'HD': {'VN': '1.5', 'SO': 'unknown', 'pb': '3.0.1'},
+        'RG': [{
+            'ID':rgid,
+            'PL':'PACBIO',
+            'DS':'READTYPE=CCS;Ipd:CodecV1=ip;PulseWidth:CodecV1=pw;BINDINGKIT=101-894-200;SEQUENCINGKIT=101-826-100;BASECALLERVERSION=5.0.0;FRAMERATEHZ=100.000000',
+            'LB':'TestLib',
+            'PU':movie_name,
+            'SM':'TestSample',
+            'PM':'SEQUELII',
+            'CM':'S/P5-C2/5.0-8M'
+        }],
+        'PG': [{
+            'ID':'ccs-6.0.0',
+            'PN':'ccs',
+            'VN':'6.0.0',
+            'DS':'Generate circular consensus sequences (ccs) from subreads.',
+            'CL':'ccs /opt/pacbio/pa-ccs/current/bin/ccs --all --streamed /data/pa/m00001e_210000_000000.consensusreadset.xml --bam /data/pa/m00001e_210000_000000.reads.bam --suppress-reports --num-threads 232 --log-level INFO --log-file /data/pa/m64020e_210000_000000.ccs.log --report-json /data/pa/m64020e_210000_000000.ccs_reports.json --report-file /data/pa/m64020e_210000_000000.ccs_reports.txt --metrics-json /data/pa/m64020e_210000_000000.zmw_metrics.json.gz --hifi-summary-json /data/pa/m64020e_210000_000000.hifi_summary.json --stderr-json-log --all-kinetics --subread-fallback'
+        }],
+        'SQ': []
+    })
+
+    return header
+
+
+@pytest.fixture
+def bam_header_with_program_group():
+    rgid = '01234567'
+    movie_name = 'm00001e_210000_000000'
+    version = '0.0.0'
+
+    model_name = 'mas15v2'
+    model_json = model.LibraryModel.build_pre_configured_model(model_name).to_json(indent=None)
+
+    header = pysam.AlignmentHeader.from_dict({
+        'HD': {'VN': '1.5', 'SO': 'unknown', 'pb': '3.0.1'},
+        'RG': [{
+            'ID':rgid,
+            'PL':'PACBIO',
+            'DS':'READTYPE=CCS;Ipd:CodecV1=ip;PulseWidth:CodecV1=pw;BINDINGKIT=101-894-200;SEQUENCINGKIT=101-826-100;BASECALLERVERSION=5.0.0;FRAMERATEHZ=100.000000',
+            'LB':'TestLib',
+            'PU':movie_name,
+            'SM':'TestSample',
+            'PM':'SEQUELII',
+            'CM':'S/P5-C2/5.0-8M'
+        }],
+        'PG': [{
+            'ID':'ccs-6.0.0',
+            'PN':'ccs',
+            'VN':'6.0.0',
+            'DS':'Generate circular consensus sequences (ccs) from subreads.',
+            'CL':'ccs /opt/pacbio/pa-ccs/current/bin/ccs --all --streamed /data/pa/m00001e_210000_000000.consensusreadset.xml --bam /data/pa/m00001e_210000_000000.reads.bam --suppress-reports --num-threads 232 --log-level INFO --log-file /data/pa/m64020e_210000_000000.ccs.log --report-json /data/pa/m64020e_210000_000000.ccs_reports.json --report-file /data/pa/m64020e_210000_000000.ccs_reports.txt --metrics-json /data/pa/m64020e_210000_000000.zmw_metrics.json.gz --hifi-summary-json /data/pa/m64020e_210000_000000.hifi_summary.json --stderr-json-log --all-kinetics --subread-fallback'
+        },
+        {
+            'ID':f'longbow-annotate-{version}',
+            'PN':'longbow',
+            'VN':version,
+            'DS':f'Annotate reads in a BAM file with segments from the model.  MODEL(s): {model_json}',
+            'CL':f'longbow annotate -m {model_name} -o test.ann.bam test.bam'
+        }],
+        'SQ': []
+    })
+
+    return header
+
+
+def test_bam_header_has_model(bam_header_with_program_group):
+    ret = bam_utils.bam_header_has_model(bam_header_with_program_group)
+    assert ret == True
+
+
+def test_bam_header_missing_model(bam_header_without_program_group):
+    ret = bam_utils.bam_header_has_model(bam_header_without_program_group)
+    assert ret == False
+
+


### PR DESCRIPTION
* Moved core logic of array-based demultiplexing to annotate command.
* Demultiplex now splits a BAM based on a read tag (e.g. YN for model name).
* Added a test for retrieving model information from a BAM header, JSON file, or a specified model name.