### PR TITLE
fixed various bugs and tests

### DIFF
--- a/src/longbow/tagfix/command.py
+++ b/src/longbow/tagfix/command.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import re
 import time
 import sys

--- a/tests/integration/test_annotate.py
+++ b/tests/integration/test_annotate.py
@@ -48,12 +48,11 @@ def test_annotate(tmpdir, input_bam, expected_bam, model_name):
 def test_annotate_from_pipe(tmpdir, input_bam, expected_bam, model_name):
     actual_bam = tmpdir.join(f"annotate_actual_out.{model_name}.pipe.bam")
 
-    proc = subprocess.Popen(
-        [sys.executable, "-m", "longbow", "annotate", "-t", 1, "-m", model_name, "-f", "-o", actual_bam],
-        stdin=subprocess.PIPE
-    )
+    args = ["annotate", "-t", 1, "-v", "INFO", "-m", model_name, "-f", "-o", str(actual_bam), "-"]
 
-    cat_file_to_pipe(input_bam, proc)
+    runner = CliRunner()
+    with open(input_bam, "rb") as fh:
+        result = runner.invoke(longbow, args, input=fh)
 
-    assert proc.returncode == 0
+    assert result.exit_code == 0
     assert_reads_files_equal(actual_bam, expected_bam)

--- a/tests/integration/test_extract.py
+++ b/tests/integration/test_extract.py
@@ -42,7 +42,7 @@ def segmented_bam_file_from_pipeline(request):
 
 
 def test_extract_from_file(tmpdir, segmented_bam_file_from_pipeline):
-    actual_file = tmpdir.join(f"extract_actual_out.bam")
+    actual_file = tmpdir.join("extract_actual_out.bam")
     args = ["extract", "-f", "-o", actual_file, segmented_bam_file_from_pipeline]
 
     runner = CliRunner()
@@ -52,13 +52,12 @@ def test_extract_from_file(tmpdir, segmented_bam_file_from_pipeline):
 
 
 def test_extract_from_pipe(tmpdir, segmented_bam_file_from_pipeline):
-    actual_file = tmpdir.join(f"extract_actual_out.pipe.bam")
+    actual_file = tmpdir.join("extract_actual_out.pipe.bam")
 
-    proc = subprocess.Popen(
-        [ sys.executable, "-m", "longbow", "extract", "-t", 1, "-f", "-o", actual_file ],
-        stdin=subprocess.PIPE
-    )
+    args = ["extract", "-f", "-o", actual_file]
 
-    cat_file_to_pipe(segmented_bam_file_from_pipeline, proc)
+    runner = CliRunner()
+    with open(segmented_bam_file_from_pipeline, "rb") as fh:
+        result = runner.invoke(longbow, args, input=fh)
 
-    assert proc.returncode == 0
+    assert result.exit_code == 0


### PR DESCRIPTION
Fixed a bunch of test failures, including a couple bugs

main fix: the introduction of `get_read_count_from_bam_index` was breaking the use of streamed input because it reads from the BAM file. Fixed by adding `seek(0)` if the input is a file, and returning `None` otherwise.

A couple missing imports: `os` in `tagfix`, `ssw` in `bam_utils`

`test_annotate` had some issue with the way the stream was working. Using `CliRunner` seems to work better.

`test_extract` had a bad argument (`-t` is not a valid arg for `extract`. In the course of debugging, I also switched to using `CliRunner` there.