### PR TITLE
fix syntaxwarning in python 3.8: `is not ""` is not recommended

### DIFF
--- a/src/longbow/commands/annotate.py
+++ b/src/longbow/commands/annotate.py
@@ -131,11 +131,11 @@ def main(pbi, threads, output_bam, model, chunk, min_length, max_length, min_rq,
     start_offset = 0
     end_offset = math.inf
 
-    if not os.path.exists(pbi) and chunk is not "":
+    if not os.path.exists(pbi) and chunk != "":
         raise ValueError(f"Chunking specified but pbi file '{pbi}' not found")
 
     if os.path.exists(pbi):
-        if chunk is not "":
+        if chunk != "":
             (chunk, num_chunks) = re.split("/", chunk)
             chunk = int(chunk)
             num_chunks = int(num_chunks)

--- a/src/longbow/commands/peek.py
+++ b/src/longbow/commands/peek.py
@@ -140,11 +140,11 @@ def main(pbi, threads, output_model, chunk, num_reads, min_length, max_length, m
     start_offset = 0
     end_offset = math.inf
 
-    if not os.path.exists(pbi) and chunk is not "":
+    if not os.path.exists(pbi) and chunk != "":
         raise ValueError(f"Chunking specified but pbi file '{pbi}' not found")
 
     if os.path.exists(pbi):
-        if chunk is not "":
+        if chunk != "":
             (chunk, num_chunks) = re.split("/", chunk)
             chunk = int(chunk)
             num_chunks = int(num_chunks)


### PR DESCRIPTION
removes syntax warnings from `is not ""`, part of closing #166