### PR TITLE
pass bam header as dict for subprocesses

### DIFF
--- a/src/longbow/commands/annotate.py
+++ b/src/longbow/commands/annotate.py
@@ -131,11 +131,11 @@ def main(pbi, threads, output_bam, model, chunk, min_length, max_length, min_rq,
     start_offset = 0
     end_offset = math.inf
 
-    if not os.path.exists(pbi) and chunk is not "":
+    if not os.path.exists(pbi) and chunk != "":
         raise ValueError(f"Chunking specified but pbi file '{pbi}' not found")
 
     if os.path.exists(pbi):
-        if chunk is not "":
+        if chunk != "":
             (chunk, num_chunks) = re.split("/", chunk)
             chunk = int(chunk)
             num_chunks = int(num_chunks)

--- a/src/longbow/commands/annotate.py
+++ b/src/longbow/commands/annotate.py
@@ -243,6 +243,7 @@ def _write_thread_fn(out_queue, out_bam_header, out_bam_file_name, disable_pbar,
     """Thread / process fn to write out all our data."""
 
     lb_models_dict = {k.name: k for k in lb_models}
+    out_bam_header = pysam.AlignmentHeader.from_dict(out_bam_header)
 
     with pysam.AlignmentFile(
         out_bam_file_name, "wb", header=out_bam_header

--- a/src/longbow/commands/convert.py
+++ b/src/longbow/commands/convert.py
@@ -86,12 +86,14 @@ def main(output_bam, default_rq, read_group_id, sample_name, min_length, max_len
     files = _get_files(input_spec)
 
     # Create header for the output bam file:
-    h = bam_utils.create_bam_header_with_program_group(
-        logger.name,
-        pysam.AlignmentHeader().from_dict({ 
-            "HD": {"VN": "1.0"},
-            "RG": [{"ID": read_group_id, "SM": sample_name}],
-        })
+    h = pysam.AlignmentHeader.from_dict(
+        bam_utils.create_bam_header_with_program_group(
+            logger.name,
+            pysam.AlignmentHeader().from_dict({
+                "HD": {"VN": "1.0"},
+                "RG": [{"ID": read_group_id, "SM": sample_name}],
+            })
+        )
     )
 
     num_reads_seen, num_reads_written = 0, 0

--- a/src/longbow/commands/correct.py
+++ b/src/longbow/commands/correct.py
@@ -365,6 +365,7 @@ def _get_field_count_and_percent_string(count, total):
 def _write_thread_fn(data_queue, out_bam_header, out_bam_file_name, barcode_uncorrectable_bam,
                      barcode_tag, corrected_tag, ccs_corrected_rq_threshold, num_reads, disable_pbar, res):
     """Thread / process fn to write out all our data."""
+    out_bam_header = pysam.AlignmentHeader.from_dict(out_bam_header)
 
     with pysam.AlignmentFile(out_bam_file_name, "wb", header=out_bam_header) as out_bam_file, \
         pysam.AlignmentFile(barcode_uncorrectable_bam, "wb", header=out_bam_header) as barcode_uncorrectable_bam, \

--- a/src/longbow/commands/demultiplex.py
+++ b/src/longbow/commands/demultiplex.py
@@ -148,6 +148,7 @@ def main(pbi, threads, out_base_name, demux_on_tag, input_bam):
 
 def _write_thread_fn(out_queue, out_bam_header, out_bam_base_name, res, read_count):
     """Thread / process fn to write out all our data."""
+    out_bam_header = pysam.AlignmentHeader.from_dict(out_bam_header)
 
     try:
         out_file_dict = {}

--- a/src/longbow/commands/extract.py
+++ b/src/longbow/commands/extract.py
@@ -192,7 +192,9 @@ def main(pbi, output_bam, force, base_padding, create_barcode_conf_file,
         delimiters = create_simple_delimiters(lb_model)
 
         # Get our header from the input bam file:
-        out_header = bam_utils.create_bam_header_with_program_group(logger.name, bam_file.header)
+        out_header = pysam.AlignmentHeader.from_dict(
+            bam_utils.create_bam_header_with_program_group(logger.name, bam_file.header)
+        )
 
         # Setup output files:
         with pysam.AlignmentFile(output_bam, "wb", header=out_header) as extracted_bam_file:

--- a/src/longbow/commands/filter.py
+++ b/src/longbow/commands/filter.py
@@ -105,7 +105,9 @@ def main(pbi, output_bam, reject_bam, model, force, input_bam):
                     f"{', '.join(lb_model.key_adapters)}")
 
         # Get our header from the input bam file:
-        out_header = bam_utils.create_bam_header_with_program_group(logger.name, bam_file.header, models=[lb_model])
+        out_header = pysam.AlignmentHeader.from_dict(
+            bam_utils.create_bam_header_with_program_group(logger.name, bam_file.header)
+        )
 
         # Setup output files:
         with pysam.AlignmentFile(output_bam, "wb", header=out_header) as passing_bam_file, \

--- a/src/longbow/commands/pad.py
+++ b/src/longbow/commands/pad.py
@@ -211,6 +211,7 @@ def _expand_tag_fn(out_queue, out_bam_header, out_bam_file_name, pbar, res, lb_m
     # Get the segment to pad out:
     # NOTE: by now we know this tag is in the model:
     barcode_seg_name = lb_model.get_segment_name_for_annotation_tag(barcode_tag)
+    out_bam_header = pysam.AlignmentHeader.from_dict(out_bam_header)
 
     with pysam.AlignmentFile(
         out_bam_file_name, "wb", header=out_bam_header

--- a/src/longbow/commands/peek.py
+++ b/src/longbow/commands/peek.py
@@ -140,11 +140,11 @@ def main(pbi, threads, output_model, chunk, num_reads, min_length, max_length, m
     start_offset = 0
     end_offset = math.inf
 
-    if not os.path.exists(pbi) and chunk is not "":
+    if not os.path.exists(pbi) and chunk != "":
         raise ValueError(f"Chunking specified but pbi file '{pbi}' not found")
 
     if os.path.exists(pbi):
-        if chunk is not "":
+        if chunk != "":
             (chunk, num_chunks) = re.split("/", chunk)
             chunk = int(chunk)
             num_chunks = int(num_chunks)

--- a/src/longbow/commands/scsplit.py
+++ b/src/longbow/commands/scsplit.py
@@ -357,6 +357,7 @@ def _sub_process_write_fn(
     out_bam_header
 ):
     """Thread / process fn to write out all our data."""
+    out_bam_header = pysam.AlignmentHeader.from_dict(out_bam_header)
 
     try:
         if do_bam_out:

--- a/src/longbow/commands/segment.py
+++ b/src/longbow/commands/segment.py
@@ -245,6 +245,7 @@ def _sub_process_write_fn(
 
     delimiters = create_simple_delimiters(model)
     logger.debug(f"Delimiter sequences for simple delimiters: %s", delimiters)
+    out_bam_header = pysam.AlignmentHeader.from_dict(out_bam_header)
 
     barcode_conf_file = None
     if create_barcode_conf_file:

--- a/src/longbow/commands/sift.py
+++ b/src/longbow/commands/sift.py
@@ -152,7 +152,9 @@ def main(pbi, output_bam, reject_bam, model, validation_model, force, stats, sum
         logger.info(f"Using %s: %s", lb_model.name, lb_model.description)
 
         # Get our header from the input bam file:
-        out_header = bam_utils.create_bam_header_with_program_group(logger.name, bam_file.header, models=[lb_model])
+        out_header = pysam.AlignmentHeader.from_dict(
+            bam_utils.create_bam_header_with_program_group(logger.name, bam_file.header)
+        )
 
         # Define a hard print interval that will periodically let the user know something is going on:
         if read_count:

--- a/src/longbow/commands/tagfix.py
+++ b/src/longbow/commands/tagfix.py
@@ -152,6 +152,7 @@ def main(threads, output_bam, force, input_bam):
 
 def _output_writer_fn(out_queue, out_bam_header, out_bam_file_name, pbar):
     """Thread / process fn to write out all our data."""
+    out_bam_header = pysam.AlignmentHeader.from_dict(out_bam_header)
 
     with pysam.AlignmentFile(
         out_bam_file_name, "wb", header=out_bam_header

--- a/src/longbow/utils/bam_utils.py
+++ b/src/longbow/utils/bam_utils.py
@@ -173,7 +173,8 @@ def compute_shard_offsets(pbi_file, num_shards):
 
 
 def create_bam_header_with_program_group(command_name, base_bam_header, description=None, models=None):
-    """Create a pysam.AlignmentHeader object with program group (PG) information populated by the given arguments.
+    """Create a dictionary with program group (PG) information populated by the given arguments, suitable for
+    converting into a pysam.AlignmentHeader object.
 
     This function is intended to be called from the 'main' function of a longbow subcommand because it uses reflection
     to pull in the first line of the docstring from the main function as the description (DS field)."""
@@ -201,9 +202,8 @@ def create_bam_header_with_program_group(command_name, base_bam_header, descript
         bam_header_dict["PG"].append(pg_dict)
     else:
         bam_header_dict["PG"] = [pg_dict]
-    out_header = pysam.AlignmentHeader.from_dict(bam_header_dict)
 
-    return out_header
+    return bam_header_dict
 
 
 def check_for_preexisting_files(file_list, exist_ok=False):


### PR DESCRIPTION
This addresses an incompatibility with python versions 3.8+, because the pysam Header object could not be passed to subprocesses.

For some reason, the test results are not totally consistent across python versions, so I don't want to increase the supported version just yet. But this change at least makes it possible to run on higher versions.

Should be merged after #167 