### PR TITLE
let inspect command read from stdin

### DIFF
--- a/src/longbow/commands/inspect.py
+++ b/src/longbow/commands/inspect.py
@@ -117,7 +117,7 @@ DEFAULT_COLOR_MAP_ENTRY = "DEFAULT"
     required=False,
     help="Store annotations from a downstream BAM file so they can be displayed on reads from previous processing steps."
 )
-@click.argument("input-bam", type=click.Path(exists=True))
+@click.argument("input-bam", default="-" if not sys.stdin.isatty() else None, type=click.File("rb"))
 def main(read_names, pbi, file_format, outdir, model, seg_score, max_length, min_rq, quick, annotated_bam, input_bam):
     """Inspect the classification results on specified reads."""
 


### PR DESCRIPTION
This allows us to use samtools to filter reads upfront. e.g. to randomly subsample 1/1000000 reads:

```
samtools view -b --subsample 0.000001 input.bam | longbow inspect -m mas_10+bulk_10x5p -o output_dir
```