### PR TITLE
moved load_model to allow stream processing

### DIFF
--- a/src/longbow/commands/annotate.py
+++ b/src/longbow/commands/annotate.py
@@ -113,10 +113,6 @@ def main(pbi, threads, output_bam, model, chunk, min_length, max_length, min_rq,
     threads = mp.cpu_count() if threads <= 0 or threads > mp.cpu_count() else threads
     logger.info(f"Running with {threads} worker subprocess(es)")
 
-    # Get our model:
-    lb_model = bam_utils.load_model(model, input_bam)
-    logger.info(f"Using {lb_model.name}: {lb_model.description}")
-
     pbi = f"{input_bam.name}.pbi" if pbi is None else pbi
     read_count = None
     read_num = 0
@@ -155,21 +151,24 @@ def main(pbi, threads, output_bam, model, chunk, min_length, max_length, min_rq,
     input_data_queue = manager.Queue(maxsize=queue_size)
     results = manager.Queue()
 
-    # Start worker sub-processes:
-    worker_pool = []
-
-    for i in range(threads):
-        p = mp.Process(
-            target=_worker_segmentation_fn,
-            args=(input_data_queue, results, i, lb_model, min_length, max_length, min_rq)
-        )
-        p.start()
-        worker_pool.append(p)
-
     pysam.set_verbosity(0)  # silence message about the .bai file not being found
     with pysam.AlignmentFile(
         input_bam if start_offset == 0 else input_bam.name, "rb", check_sq=False, require_index=False
     ) as bam_file:
+        # Get our model:
+        lb_model = bam_utils.load_model(model, bam_file)
+        logger.info(f"Using {lb_model.name}: {lb_model.description}")
+
+        # Start worker sub-processes:
+        worker_pool = []
+
+        for i in range(threads):
+            p = mp.Process(
+                target=_worker_segmentation_fn,
+                args=(input_data_queue, results, i, lb_model, min_length, max_length, min_rq)
+            )
+            p.start()
+            worker_pool.append(p)
 
         # If we're chunking, advance to the specified virtual file offset.
         if start_offset > 0:

--- a/src/longbow/commands/correct.py
+++ b/src/longbow/commands/correct.py
@@ -189,12 +189,11 @@ def main(pbi, threads, output_bam, model, force, restrict_to_allowlist, barcode_
     # process_input_data_queue = manager.Queue()
     results = manager.Queue()
 
-    # Get our model:
-    lb_model = bam_utils.load_model(model, input_bam)
-    logger.info(f"Using {lb_model.name}: {lb_model.description}")
-
     pysam.set_verbosity(0)  # silence message about the .bai file not being found
     with pysam.AlignmentFile(input_bam, "rb", check_sq=False, require_index=False) as bam_file:
+        # Get our model:
+        lb_model = bam_utils.load_model(model, bam_file)
+        logger.info(f"Using {lb_model.name}: {lb_model.description}")
 
         # Get our barcode length:
         barcode_length = _get_barcode_tag_length_from_model(lb_model, barcode_tag)

--- a/src/longbow/commands/extract.py
+++ b/src/longbow/commands/extract.py
@@ -138,13 +138,12 @@ def main(pbi, output_bam, force, base_padding, create_barcode_conf_file,
         if read_count:
             logger.info("About to Extract segments from %d reads", read_count)
 
-    # Get our model:
-    lb_model = bam_utils.load_model(model, input_bam)
-    logger.info(f"Using {lb_model.name}: {lb_model.description}")
-
     # Open our input bam file:
     pysam.set_verbosity(0)
     with pysam.AlignmentFile(input_bam, "rb", check_sq=False, require_index=False) as bam_file:
+        # Get our model:
+        lb_model = bam_utils.load_model(model, bam_file)
+        logger.info(f"Using {lb_model.name}: {lb_model.description}")
 
         # Validate our command line arguments:
         if lb_model.has_coding_region:

--- a/src/longbow/commands/filter.py
+++ b/src/longbow/commands/filter.py
@@ -85,16 +85,15 @@ def main(pbi, output_bam, reject_bam, model, force, input_bam):
     # Check to see if the output files exist:
     bam_utils.check_for_preexisting_files([output_bam, reject_bam], exist_ok=force)
 
-    # Get our model:
-    lb_model = bam_utils.load_model(model, input_bam)
-    logger.info(f"Using {lb_model.name}: {lb_model.description}")
-
-    logger.info(f"Writing reads that conform to the model to: {output_bam}")
-    logger.info(f"Writing reads that do not conform to the model to: {reject_bam}")
-
     # Open our input bam file:
     pysam.set_verbosity(0)
     with pysam.AlignmentFile(input_bam, "rb", check_sq=False, require_index=False) as bam_file:
+        # Get our model:
+        lb_model = bam_utils.load_model(model, bam_file)
+        logger.info(f"Using {lb_model.name}: {lb_model.description}")
+
+        logger.info(f"Writing reads that conform to the model to: {output_bam}")
+        logger.info(f"Writing reads that do not conform to the model to: {reject_bam}")
 
         logger.info(f"Filtering according to {lb_model.name} model ordered key adapters: "
                     f"{', '.join(lb_model.key_adapters)}")

--- a/src/longbow/commands/inspect.py
+++ b/src/longbow/commands/inspect.py
@@ -129,13 +129,12 @@ def main(read_names, pbi, file_format, outdir, model, seg_score, max_length, min
     if annotated_bam is not None:
         anns, name_map = _load_annotations(annotated_bam)
 
-    # Get our model:
-    lb_model = bam_utils.load_model(model, input_bam)
-    logger.info(f"Using {lb_model.name}: {lb_model.description}")
-
     # Open our bam file:
     pysam.set_verbosity(0)
     with pysam.AlignmentFile(input_bam, "rb", check_sq=False, require_index=False) as bam_file:
+        # Get our model:
+        lb_model = bam_utils.load_model(model, bam_file)
+        logger.info(f"Using {lb_model.name}: {lb_model.description}")
 
         logger.info(f"Figure drawing mode: {'simplified' if quick else 'extended'}")
 

--- a/src/longbow/commands/pad.py
+++ b/src/longbow/commands/pad.py
@@ -102,10 +102,6 @@ def main(threads, output_bam, model, force, barcode_tag, new_barcode_tag, expand
     if num_reads:
         logger.info(f"About to pad {num_reads} reads.")
 
-    # Get our model:
-    lb_model = bam_utils.load_model(model, input_bam)
-    logger.info(f"Using {lb_model.name}: {lb_model.description}")
-
     # Configure process manager:
     # NOTE: We're using processes to overcome the Global Interpreter Lock.
     manager = mp.Manager()
@@ -133,6 +129,9 @@ def main(threads, output_bam, model, force, barcode_tag, new_barcode_tag, expand
         leave=False,
         disable=not sys.stdin.isatty(),
     ) as pbar:
+        # Get our model:
+        lb_model = bam_utils.load_model(model, bam_file)
+        logger.info(f"Using {lb_model.name}: {lb_model.description}")
 
         # Verify that the given model actually has the barcode to change:
         if not lb_model.has_annotation_tag(barcode_tag):

--- a/src/longbow/commands/segment.py
+++ b/src/longbow/commands/segment.py
@@ -102,10 +102,6 @@ def main(threads, output_bam, create_barcode_conf_file, model, ignore_cbc_and_um
     if total_reads:
         logger.info(f"About to segment {total_reads} reads.")
 
-    # Get our model:
-    lb_model = bam_utils.load_model(model, input_bam)
-    logger.info(f"Using {lb_model.name}: {lb_model.description}")
-
     # Configure process manager:
     # NOTE: We're using processes to overcome the Global Interpreter Lock.
     manager = mp.Manager()
@@ -133,6 +129,9 @@ def main(threads, output_bam, create_barcode_conf_file, model, ignore_cbc_and_um
         leave=False,
         disable=not sys.stdin.isatty(),
     ) as pbar:
+        # Get our model:
+        lb_model = bam_utils.load_model(model, bam_file)
+        logger.info(f"Using {lb_model.name}: {lb_model.description}")
 
         if ignore_cbc_and_umi:
             logger.info("Ignoring CBC / UMI - all split elements will be written.")

--- a/src/longbow/commands/sift.py
+++ b/src/longbow/commands/sift.py
@@ -102,10 +102,6 @@ def main(pbi, output_bam, reject_bam, model, force, stats, summary_stats, ignore
         if read_count:
             logger.info("About to Sift %d reads", read_count)
 
-    # Get our model:
-    lb_model = bam_utils.load_model(model, input_bam)
-    logger.info(f"Using {lb_model.name}: {lb_model.description}")
-
     reads_to_ignore = set()
     if ignore_list and os.path.exists(ignore_list):
         logger.info(f"Ingesting read ignore list: {ignore_list}")
@@ -125,6 +121,9 @@ def main(pbi, output_bam, reject_bam, model, force, stats, summary_stats, ignore
     # Open our input bam file:
     pysam.set_verbosity(0)
     with pysam.AlignmentFile(input_bam, "rb", check_sq=False, require_index=False) as bam_file:
+        # Get our model:
+        lb_model = bam_utils.load_model(model, bam_file)
+        logger.info(f"Using {lb_model.name}: {lb_model.description}")
 
         # Get our header from the input bam file:
         out_header = pysam.AlignmentHeader.from_dict(

--- a/src/longbow/commands/stats.py
+++ b/src/longbow/commands/stats.py
@@ -86,10 +86,6 @@ def main(pbi, output_prefix, model, do_simple_splitting, input_bam):
     if read_count:
         logger.info("Collecting stats on %d reads", read_count)
 
-    # Get our model:
-    lb_model = bam_utils.load_model(model, input_bam)
-    logger.info(f"Using {lb_model.name}: {lb_model.description}")
-
     if do_simple_splitting:
         logger.warning("Simple splitting is now the default.  \"-s\" / \"--do-simple-splitting\" is now DEPRECATED.")
     do_simple_splitting = True
@@ -115,6 +111,9 @@ def main(pbi, output_prefix, model, do_simple_splitting, input_bam):
         leave=False,
         disable=not sys.stdin.isatty(),
     ) as pbar:
+        # Get our model:
+        lb_model = bam_utils.load_model(model, bam_file)
+        logger.info(f"Using {lb_model.name}: {lb_model.description}")
 
         # Prepare our delimiters for segmentation below:
         delimiters = segment.create_simple_delimiters(lb_model)

--- a/src/longbow/commands/train.py
+++ b/src/longbow/commands/train.py
@@ -78,8 +78,9 @@ def main(
     logger.info(f"Running with {threads} worker subprocess(es)")
 
     # Get our model:
-    m = bam_utils.load_model(model, training_bam)
-    logger.info(f"Using {m.name}: {m.description}")
+    with pysam.AlignmentFile(training_bam, "rb", check_sq=False, require_index=False) as bam_file:
+        m = bam_utils.load_model(model, bam_file)
+        logger.info(f"Using {m.name}: {m.description}")
 
     training_seqs = load_training_seqs(m, num_training_samples, threads, training_bam)
 

--- a/src/longbow/utils/bam_utils.py
+++ b/src/longbow/utils/bam_utils.py
@@ -222,14 +222,10 @@ def check_for_preexisting_files(file_list, exist_ok=False):
         sys.exit(1)
 
 
-def load_model(model, input_bam=None):
-
+def load_model(model, bam_file=None):
     # Get our model:
-    if model is None and input_bam is not None:
-        pysam.set_verbosity(0)
-        input_bam_path = input_bam if type(input_bam) is str else input_bam.name
-        with pysam.AlignmentFile(input_bam_path, "rb", check_sq=False, require_index=False) as bam_file:
-            lb_model = LibraryModel.from_json_obj(get_model_from_bam_header(bam_file.header))
+    if model is None and bam_file is not None:
+        lb_model = LibraryModel.from_json_obj(get_model_from_bam_header(bam_file.header))
     elif model is not None and LibraryModel.has_prebuilt_model(model):
         lb_model = LibraryModel.build_pre_configured_model(model)
     else:


### PR DESCRIPTION
This PR closes #199 (I hope). As described in the issue, various longbow commands were failing when reading from `stdin`. This PR changes `load_model()` to expect an open `pysam.AlignmentFile` rather than a stream or filename, and moves the call inside the `with` statement where the file is being read (which is almost always what happens immediately after loading a model from a BAM file).

This _should_ be okay to do, as the model is stored in the header if at all, and so `load_model` will only consume the first piece of the stream and none of the reads.