### PR TITLE
rebuild HMM inside subprocesses

### DIFF
--- a/src/longbow/commands/annotate.py
+++ b/src/longbow/commands/annotate.py
@@ -281,6 +281,7 @@ def _worker_segmentation_fn(in_queue, out_queue, worker_num, lb_model, min_lengt
     """Function to run in each subthread / subprocess.
     Segments each read and place the segments in the output queue."""
 
+    lb_model.build()  # rebuild HMM inside subprocess
     num_reads_processed, num_reads_segmented = 0, 0
 
     while True:

--- a/src/longbow/commands/inspect.py
+++ b/src/longbow/commands/inspect.py
@@ -721,7 +721,7 @@ def draw_extended_state_sequence(seq, path, logp, read, out, show_seg_score, lib
 def _expand_cigar_sequence(cigar_path):
     """Expand a cigar sequence to a `ppath` list ala the model."""
     ppath = []
-    op_re = re.compile("([A-Za-z]+)(\d+)")
+    op_re = re.compile(r"([A-Za-z]+)(\d+)")
     for p in cigar_path:
         # Get our segment:
         seg = re.split(":", p)[0]

--- a/src/longbow/commands/peek.py
+++ b/src/longbow/commands/peek.py
@@ -304,6 +304,9 @@ def _worker_attempt_segmentations_fn(in_queue, out_queue, worker_num, min_length
     """Function to run in each subthread / subprocess.
     Segments each read and place the segments in the output queue."""
 
+    for model in models.values():
+        model.build()  # rebuild HMM inside subprocess
+
     num_reads_segmented = 0
 
     while True:

--- a/src/longbow/commands/segment.py
+++ b/src/longbow/commands/segment.py
@@ -235,6 +235,8 @@ def _sub_process_write_fn(
 ):
     """Thread / process fn to write out all our data."""
 
+    model.build()  # rebuild HMM inside subprocess
+
     delimiters = create_simple_delimiters(model)
     logger.debug("Delimiter sequences for simple delimiters: {delimiters}")
     out_bam_header = pysam.AlignmentHeader.from_dict(out_bam_header)


### PR DESCRIPTION
This fixes some subtle weirdness with `annotate`. It appears that the pomegranate model might not be perfectly passed into a subprocess and this can result in small changes to the resulting fit (which was causing a failing integration test)